### PR TITLE
Include gapi-chrome-apps.js last in scripts.

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,6 @@
 
     <!-- JavaScript at the bottom for fast page loading -->
     <script src="js/vendor/jquery-1.8.0.min.js"></script>
-    <script src="js/vendor/gapi-chrome-apps.js"></script>
     <script src="js/constants.js"></script>
     <script src="js/game.js"></script>
     <script src="js/inventory.js"></script>
@@ -57,6 +56,7 @@
     <script src="js/model.js"></script>
     <script src="js/player.js"></script>
     <script src="js/index.js"></script>
+    <script src="js/vendor/gapi-chrome-apps.js"></script>
 
 </body>
 </html>

--- a/js/vendor/gapi-chrome-apps.js
+++ b/js/vendor/gapi-chrome-apps.js
@@ -30,6 +30,9 @@
 (function () {
   if (typeof gapi !== 'undefined')
     throw new Error('gapi already defined.');
+  if (typeof gapiIsLoaded !== 'function')
+    throw new Error('gapiIsLoaded callback function must be defined prior to ' +
+                    'loading gapi-chrome-apps.js');
 
   // If not running in a chrome packaged app, load web gapi:
   if (!(chrome && chrome.app && chrome.app.runtime)) {


### PR DESCRIPTION
Fixes race condition for loading apis.google.com/js/client.js
and loading the the callback function defined in index.js.
